### PR TITLE
Re-work thing types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Bulb names are reported by the Lifx API, so they should automatically show up in
 ## Untested but _Should Work_
  
 * All other Lifx bulbs
-    * Represented as `dimmableColorLight` or `dimmableLight` based on their self-reported color and white temperature abilities
+    * Represented as `onOffColorLight`, `dimmableColorLight` or `dimmableLight` based on their self-reported color and white temperature abilities
 
 # Requirements
 

--- a/pkg/lifx_device.py
+++ b/pkg/lifx_device.py
@@ -66,20 +66,22 @@ class LifxBulb(LifxDevice):
                                                            'type': 'string'
                                                        },
                                                        hsv_to_rgb(*self.hsv()))
+        elif gateway_addon.API_VERSION >= 2 and self.is_white_temperature():
+            print("Bulb supports white temperature") 
+            self.type = 'dimmableColorLight'
+
+            self.properties['colorTemperature'] = \
+                LifxBulbProperty(self,
+                                 'colorTemperature',
+                                 {  
+                                     'type': 'number',
+                                     'unit': 'kelvin',
+                                     'min': 1500,
+                                     'max': 9000
+                                 },
+                                 self.temperature())
         else:
             self.type = 'dimmableLight'
-
-        if gateway_addon.API_VERSION >= 2 and self.is_white_temperature():
-            print("Bulb supports white temperature") 
-            self.properties['colorTemperature'] = LifxBulbProperty(self,
-                                                                   'colorTemperature',
-                                                                   {  
-                                                                      'type': 'number',
-                                                                      'unit': 'kelvin',
-                                                                      'min': 1500,
-                                                                      'max': 9000
-                                                                   },
-                                                                   self.temperature())
 
         self.properties['level'] = LifxBulbProperty(self,
                                                    'level',

--- a/pkg/lifx_device.py
+++ b/pkg/lifx_device.py
@@ -58,7 +58,7 @@ class LifxBulb(LifxDevice):
 
         if self.is_color():
             print("Bulb supports color")
-            self.type = 'dimmableColorLight'
+            self.type = 'onOffColorLight'
 
             self.properties['color'] = LifxBulbProperty(self,
                                                        'color',
@@ -83,16 +83,16 @@ class LifxBulb(LifxDevice):
         else:
             self.type = 'dimmableLight'
 
-        self.properties['level'] = LifxBulbProperty(self,
-                                                   'level',
-                                                   {  
-                                                      'type': 'number',
-                                                      'unit': 'percent',
-                                                      'min': 0,
-                                                      'max': 100
-                                                   },
-                                                   self.brightness())
-
+        if not self.is_color()
+            self.properties['level'] = LifxBulbProperty(self,
+                                                       'level',
+                                                       {  
+                                                          'type': 'number',
+                                                          'unit': 'percent',
+                                                          'min': 0,
+                                                          'max': 100
+                                                       },
+                                                       self.brightness())
 
         self.properties['on'] = LifxBulbProperty(self, 
                                                  'on', 


### PR DESCRIPTION
After lots of team discussion yesterday, we decided the following:
1. Full-color (i.e. RGB/HSV) bulbs should not have a level property, as it's redundant. Level/brightness is just a component of the color.
2. Bulbs that have both color-temperature control and RGB control should only have the `color` property, as the color temperature can be set/simulated via that property. Having both leads to an incredibly confusing UI.